### PR TITLE
Replace Plasmacore with Kirigami to render icon in plasma 6

### DIFF
--- a/contents/ui/CompactRepresentation.qml
+++ b/contents/ui/CompactRepresentation.qml
@@ -30,6 +30,6 @@ Loader {
 
     Kirigami.Icon {
         anchors.fill: parent
-        source: Qt.resolvedUrl(Utils.chooseIconPath(Plasmoid.configuration, Utils.getBackgroundColorContrastFromHex(PlasmaCore.Theme.backgroundColor)))
+        source: Qt.resolvedUrl(Utils.chooseIconPath(Plasmoid.configuration, Utils.getBackgroundColorContrastFromHex(Kirigami.Theme.backgroundColor)))
     }
 }

--- a/contents/ui/CompactRepresentation.qml
+++ b/contents/ui/CompactRepresentation.qml
@@ -4,7 +4,6 @@ import QtQuick.Layouts
 
 // KDE modules
 import org.kde.kirigami as Kirigami
-import org.kde.plasma.core as PlasmaCore
 import org.kde.plasma.plasmoid
 
 // Local imports

--- a/contents/ui/ConfigAppearance.qml
+++ b/contents/ui/ConfigAppearance.qml
@@ -12,7 +12,6 @@ import QtQuick.Layouts
 import org.kde.iconthemes as KIconThemes
 import org.kde.kirigami as Kirigami
 import org.kde.ksvg as KSvg
-import org.kde.plasma.core as PlasmaCore
 import org.kde.plasma.plasmoid
 
 // Local imports

--- a/tests/test-spanish.qml
+++ b/tests/test-spanish.qml
@@ -1,7 +1,6 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
-import org.kde.plasma.core 2.0 as PlasmaCore
 import org.kde.plasma.components 3.0 as PlasmaComponents3
 import org.kde.plasma.plasmoid 2.0
 import org.kde.kirigami 2.20 as Kirigami


### PR DESCRIPTION
Hello, thank you for K-Ollama-Plasmoid. I was looking for a simple KDE app to interface with my local ollama and this works well. I made some changes to it, and am contributing them back for your consideration.

This first one addresses the app icon not rendering in my task bar.

PlasmaCore.Theme seems no longer available in Plasma 6, causing a TypeError when the widget tries to determine the background color for adaptive icon selection. This results in the widget icon not rendering in the panel bar. This fix replaces PlasmaCore.Theme.backgroundColor with Kirigami.Theme.backgroundColor.