### PR TITLE
Only poll when the app is expanded

### DIFF
--- a/contents/ui/ConnectionManager.qml
+++ b/contents/ui/ConnectionManager.qml
@@ -29,7 +29,7 @@ Item {
     property int disconnectedPollInterval: 5000
     property int timeoutMs: 3000         // ms before aborting a single request
     property string endpoint: "version"  // Lightweight connectivity check endpoint
-    property bool running: true
+    property bool running: false
     // Optional server base URL (e.g. "http://127.0.0.1:11434"). If empty, falls back to default.
     property string serverBase: ""
 

--- a/contents/ui/ConnectionManager.qml
+++ b/contents/ui/ConnectionManager.qml
@@ -37,8 +37,19 @@ Item {
         id: pollTimer
         interval: root.interval
         repeat: true
-        running: root.running
+        running: false
         onTriggered: root.check()
+    }
+
+    // Manage timer start/stop imperatively to avoid breaking QML bindings.
+    // Any imperative stop()/start() call on a declaratively bound property
+    // permanently replaces the binding with a static value.
+    onRunningChanged: {
+        if (root.running) {
+            pollTimer.start();
+        } else {
+            pollTimer.stop();
+        }
     }
 
     // react to status changes: adjust poll interval
@@ -47,7 +58,7 @@ Item {
         pollTimer.interval = (status === "connected") ? root.connectedPollInterval : root.disconnectedPollInterval;
 
         // restart the timer so the new interval takes effect immediately
-        if (pollTimer.running) {
+        if (root.running) {
             pollTimer.stop();
             pollTimer.start();
         }
@@ -135,9 +146,7 @@ Item {
     }
 
     Component.onCompleted: {
-        // start polling immediately
-    Utils.debugLog('debug', "ConnectionManager: Component.onCompleted, running=", root.running, "interval=", pollTimer.interval);
-        if (root.running) pollTimer.start();
+        Utils.debugLog('debug', "ConnectionManager: Component.onCompleted, running=", root.running, "interval=", pollTimer.interval);
     }
 
     Component.onDestruction: {

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -112,6 +112,10 @@ PlasmoidItem {
         }
     }
 
+    onExpandedChanged: {
+        if (root.expanded) connMgr.check()
+    }
+
     // Use Utils.getServerUrl(baseUrl, endpoint) to avoid coupling to Plasmoid internals
     function getServerUrl(endpoint) {
         return Utils.getServerUrl(Plasmoid.configuration.ollamaServerUrl, endpoint);
@@ -588,6 +592,7 @@ PlasmoidItem {
         interval: 5000
         timeoutMs: 2500
         serverBase: Plasmoid.configuration.ollamaServerUrl || ''
+        running: root.expanded
     }
 
     Component.onCompleted: {


### PR DESCRIPTION
Another change for your consideration.

I don't run ollama server all the time. The connection status checker was polling the Ollama server continuously on a 5 second interval, even when the widget was minimized in task bar. This results in unnecessary network requests in the background at all times.

This fix binds the polling timer to root.expanded so that:
- Polling only runs while the widget is expanded
- An immediate connectivity check is triggered when the widget is opened
- The adaptive interval (5s disconnected / 30s connected) is preserved when polling is active
- Desktop widgets (always expanded) are unaffected